### PR TITLE
rename makefile since its GNU specific

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -81,11 +81,11 @@ zip.in:
 	echo $(title)256.nes >> $@
 	echo zip.in >> $@
 
-$(objdir)/index.txt: makefile
+$(objdir)/index.txt: GNUmakefile
 	echo Files produced by build tools go here > $@
 
 clean:
-	-rm $(objdir)/*.o $(objdir)/*.s $(objdir)/*.chr
+	rm -f $(objdir)/*.o $(objdir)/*.s $(objdir)/*.chr
 
 # Rules for PRG ROM
 


### PR DESCRIPTION
trying to compile with `bmake` yields this wonderful output

> bmake: "/makefile" line 48: Invalid line 'ifeq ($(OS), Windows_NT)', expanded to 'ifeq '
> bmake: "/makefile" line 51: Invalid line 'else'
> bmake: "/makefile" line 54: Invalid line 'endif'
> bmake: "/makefile" line 105: warning: duplicate script for target "obj/nes/%.o" ignored
> bmake: "/makefile" line 102: warning: using previous script for "obj/nes/%.o" defined here
> bmake: Fatal errors encountered -- cannot continue
> bmake: stopped in /

`info make` recommends calling the makefile "GNUmakefile" if it relies on GNU make features

additionally, `-rm` should be `rm -f`, or `${RM}`, as `--force` will hide errors about failing to delete an inexistent file